### PR TITLE
Add optional reassignment override to reporting service times

### DIFF
--- a/app/services/reporting_service/service.py
+++ b/app/services/reporting_service/service.py
@@ -472,18 +472,14 @@ async def generate_excel_report(session: AsyncSession, mes: int) -> StreamingRes
     ).round(2)
     df_export = df_export.drop(columns=["ODOMETRO"])
 
-    df_export["tracto_sort"] = pd.to_numeric(
-        df_export["NO_TRACTO"].str.replace("ECO", "").str.strip(),
-        errors="coerce",
-    )
     df_export["hora_sort"] = pd.to_timedelta(
         df_export["HORA_CARGA"].apply(_hora_to_hms)
     )
 
     df_export = (
         df_export
-        .sort_values(["tracto_sort", "FECHA_CARGA", "hora_sort"])
-        .drop(columns=["tracto_sort", "hora_sort"])
+        .sort_values(["FECHA_CARGA", "hora_sort"])
+        .drop(columns=["hora_sort"])
         .reset_index(drop=True)
     )
 

--- a/app/services/reporting_service/service.py
+++ b/app/services/reporting_service/service.py
@@ -462,14 +462,18 @@ async def generate_excel_report(session: AsyncSession, mes: int) -> StreamingRes
     ).round(2)
     df_export = df_export.drop(columns=["ODOMETRO"])
 
+    df_export["tracto_sort"] = pd.to_numeric(
+        df_export["NO_TRACTO"].str.replace("ECO", "").str.strip(),
+        errors="coerce",
+    )
     df_export["hora_sort"] = pd.to_timedelta(
         df_export["HORA_CARGA"].apply(_hora_to_hms)
     )
 
     df_export = (
         df_export
-        .sort_values(["FECHA_CARGA", "hora_sort"])
-        .drop(columns=["hora_sort"])
+        .sort_values(["tracto_sort", "FECHA_CARGA", "hora_sort"])
+        .drop(columns=["tracto_sort", "hora_sort"])
         .reset_index(drop=True)
     )
 

--- a/app/services/reporting_service/service.py
+++ b/app/services/reporting_service/service.py
@@ -194,7 +194,7 @@ async def generate_excel_report(session: AsyncSession, mes: int) -> StreamingRes
     )
     df = (
         df[df["eco_num"].notna()]
-        .sort_values(["eco_num", "fecha_carga", "hora_carga"])
+        .sort_values(["fecha_carga", "hora_carga"])
         .drop(columns=["eco_num"])
     )
 
@@ -465,15 +465,11 @@ async def generate_excel_report(session: AsyncSession, mes: int) -> StreamingRes
     df_export["hora_sort"] = pd.to_timedelta(
         df_export["HORA_CARGA"].apply(_hora_to_hms)
     )
-    df_export["eco_num"] = pd.to_numeric(
-        df_export["NO_TRACTO"].str.replace("ECO", "", regex=False).str.strip(),
-        errors="coerce",
-    )
 
     df_export = (
         df_export
-        .sort_values(["eco_num", "FECHA_CARGA", "hora_sort"])
-        .drop(columns=["eco_num", "hora_sort"])
+        .sort_values(["FECHA_CARGA", "hora_sort"])
+        .drop(columns=["hora_sort"])
         .reset_index(drop=True)
     )
 

--- a/app/services/reporting_service/service.py
+++ b/app/services/reporting_service/service.py
@@ -111,14 +111,18 @@ async def generate_excel_report(session: AsyncSession, mes: int) -> StreamingRes
     df["fecha_carga"]    = pd.to_datetime(df["fecha_carga"],    dayfirst=True, errors="coerce")
     df["fecha_descarga"] = pd.to_datetime(df["fecha_descarga"], dayfirst=True, errors="coerce")
 
-    def hora_fmt(row, campo, title):
-        if title in horas_reasig:
+    def hora_fmt(row, campo, title, use_reasig=False):
+        if use_reasig and title in horas_reasig:
             return horas_reasig[title].strftime("%H:%M:%S")
         h = pd.to_datetime(row[campo], errors="coerce")
         return None if pd.isna(h) else h.strftime("%H:%M:%S")
 
-    df["hora_descarga"] = df.apply(lambda r: hora_fmt(r, "hora_descarga", r["Title"]), axis=1)
-    df["hora_carga"]    = df.apply(lambda r: hora_fmt(r, "hora_carga",    r["Title"]), axis=1)
+    df["hora_descarga"] = df.apply(
+        lambda r: hora_fmt(r, "hora_descarga", r["Title"], use_reasig=True), axis=1
+    )
+    df["hora_carga"] = df.apply(
+        lambda r: hora_fmt(r, "hora_carga", r["Title"], use_reasig=False), axis=1
+    )
 
     # uniforma ECO
     df["No. Económico"] = df["No. Económico"].apply(

--- a/app/services/reporting_service/service.py
+++ b/app/services/reporting_service/service.py
@@ -261,7 +261,6 @@ async def generate_excel_report(session: AsyncSession, mes: int) -> StreamingRes
                 "COMISION_CLIENTE",
                 "COMISION_OPERADOR",
                 "GASTOS_OPERADOR",
-                "PEAJES_VIAPASS",
                 "PEAJES_EFECTIVO",
             ]:
                 d[c] = 0
@@ -466,11 +465,15 @@ async def generate_excel_report(session: AsyncSession, mes: int) -> StreamingRes
     df_export["hora_sort"] = pd.to_timedelta(
         df_export["HORA_CARGA"].apply(_hora_to_hms)
     )
+    df_export["eco_num"] = pd.to_numeric(
+        df_export["NO_TRACTO"].str.replace("ECO", "", regex=False).str.strip(),
+        errors="coerce",
+    )
 
     df_export = (
         df_export
-        .sort_values(["FECHA_CARGA", "hora_sort"])
-        .drop(columns=["hora_sort"])
+        .sort_values(["eco_num", "FECHA_CARGA", "hora_sort"])
+        .drop(columns=["eco_num", "hora_sort"])
         .reset_index(drop=True)
     )
 

--- a/app/services/reporting_service/service.py
+++ b/app/services/reporting_service/service.py
@@ -261,6 +261,7 @@ async def generate_excel_report(session: AsyncSession, mes: int) -> StreamingRes
                 "COMISION_CLIENTE",
                 "COMISION_OPERADOR",
                 "GASTOS_OPERADOR",
+                "PEAJES_VIAPASS",
                 "PEAJES_EFECTIVO",
             ]:
                 d[c] = 0
@@ -355,6 +356,15 @@ async def generate_excel_report(session: AsyncSession, mes: int) -> StreamingRes
     df_final["FECHA_CARGA"] = pd.to_datetime(df_final["FECHA_CARGA"], errors="coerce")
     df_export = df_final[df_final["FECHA_CARGA"].dt.month == mes].copy()
     df_export["ODOMETRO"] = None
+
+    # Ordena globalmente por fecha y hora de carga
+    df_export["hora_sort"] = pd.to_timedelta(
+        df_export["HORA_CARGA"].apply(_hora_to_hms)
+    )
+    df_export = (
+        df_export.sort_values(["FECHA_CARGA", "hora_sort"])
+        .drop(columns=["hora_sort"])
+    )
 
     # ╠═══════════════ 8. DATOS SCANIA (km/diesel/adblue) ════════════════╣
     vin_map = await get_vehicle_map()

--- a/app/services/scania_auth/auth.py
+++ b/app/services/scania_auth/auth.py
@@ -1,6 +1,7 @@
 # app/services/scania_auth/auth.py
 
 from typing import Optional
+import httpx
 from app.core.redis_client import get_redis_client
 from app.core.security import create_challenge_response
 from app.config import settings
@@ -35,7 +36,10 @@ class ScaniaAuthService:
         refresh_token = await self._get_refresh_token_from_redis()
         if not refresh_token:
             return await self.fetch_new_token()
-        token_data = await self.client.refresh_token(refresh_token)
+        try:
+            token_data = await self.client.refresh_token(refresh_token)
+        except httpx.HTTPStatusError:
+            return await self.fetch_new_token()
         await self._save_tokens_to_redis(token_data["token"], token_data["refreshToken"])
         return token_data["token"]
 


### PR DESCRIPTION
## Summary
- add `use_reasig` flag to `hora_fmt` so reassignment times are applied only when needed
- use reassignment override for `hora_descarga` but keep original `hora_carga`

## Testing
- `pytest -q` *(fails: redis.exceptions.ConnectionError: Error Multiple exceptions: [Errno 111] Connect call failed ('::1', 6379, 0, 0), [Errno 111] Connect call failed ('127.0.0.1', 6379))*

------
https://chatgpt.com/codex/tasks/task_e_6893e3c48dec8321ae20ddf631936bd4